### PR TITLE
Update gemspec to include link to repo

### DIFF
--- a/lock_key.gemspec
+++ b/lock_key.gemspec
@@ -11,6 +11,11 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Uses redis to take out multi-threaded/processed safe locks}
   gem.summary       = %q{Uses redis to take out multi-threaded/processed safe locks}
   gem.homepage      = ""
+  
+  gem.metadata = {
+    "bug_tracker_uri"   => "https://github.com/hassox/lock_key/issues",
+    "source_code_uri"   => "https://github.com/hassox/lock_key/tree/v#{LockKey::VERSION}",
+  }
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I looked around for locks and found your gem. https://rubygems.org/gems/lock_key

I dowloaded the gem and read the source. I thought it look a  little weird that it did't have a source link so I added it.